### PR TITLE
Fix issue #1: remove unnecessary f string from TaskFile.py

### DIFF
--- a/TaskFile.py
+++ b/TaskFile.py
@@ -50,7 +50,7 @@ tgz_file = root_dir / "dist" / f"taskcond-{taskcond.__version__}.tar.gz"
 register(
     Task(
         name="build",
-        shell_command=f"python -m build",
+        shell_command="python -m build",
         output_files=(wheel_file, tgz_file),
         description="build package",
     )


### PR DESCRIPTION
This pull request fixes #1.

The issue stated that there was an unnecessary f-string on `TaskFile.py` line 53. The provided patch shows that the line `shell_command=f"python -m build",` was changed to `shell_command="python -m build",`. This change successfully removes the `f` prefix from the string literal, which was indeed unnecessary as there were no interpolated expressions within the string. Therefore, the issue has been resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌